### PR TITLE
abrvenik/smaller reponse on post

### DIFF
--- a/Chiraba/mainserver.js
+++ b/Chiraba/mainserver.js
@@ -63,7 +63,7 @@ const server = http.createServer((req, res) => {
             queryObject.list == "customList"
           ) {
             customList.push(request_body);
-            responseJson = customList;
+            responseJson = request_body;
           } else {
             if (
               queryObject.list &&

--- a/Chiraba/mainserver.js
+++ b/Chiraba/mainserver.js
@@ -27,6 +27,7 @@ const server = http.createServer((req, res) => {
     msg = "";
     let responseJson = "";
     // regardless of request method:
+    c++;
     if (
       queryObject.size == null &&
       queryObject.delay == null &&


### PR DESCRIPTION
POSTing to the customList becomes bandwidth-intensive when the list becomes large. Instead, we should just return what we were sent. 

Request counter is intended to increment, but that functionality was lost in the refactor